### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Xt-EHR FHIR Implementation Guide
-<br> </br>
+
 ### Publication
 This ImplementationGuide is published in the following locations:
 
-Continuous Build: __http://build.fhir.org/ig/Xt-EHR/xt-ehr-common__
-Canonical / permanent URL: 
-<br/>
+* Continuous build of the `main` branch: __https://xt-ehr.github.io/xt-ehr-common/__
+* Continuous builds of all branches: __https://build.fhir.org/ig/Xt-EHR/xt-ehr-common/branches/__
+* Canonical / permanent URL: Not available yet, but will most likely be something like https://www.xt-ehr.eu/specifications/fhir/xt-ehr-common/
+
+Note that the builds at the `build.fhir.org` infrastructure are temporary and are emptied occasionally.
 
 ### Issues
 Issues and change requests are managed here:  
 
 Issues:  __https://github.com/Xt-EHR/xt-ehr-common/issues)__  
-Issues board:  __https://github.com/xxxxxx__  
+Issues board:  __https://github.com/orgs/Xt-EHR/projects/2__  
 
 ---
+The Xt-EHR action is co-funded by the European Union, EU4Health Program 2021-2027, under Grant Agreement Nr.º 101128085.
+![A EU funded project.](https://xt-ehr.github.io/xt-ehr-common/assets/images/eu.png)


### PR DESCRIPTION
Add information on the location of the GitHub Pages publication. This should be the default, as the build.fhir.org infrastructure is volatile.

Clarify that the canonical URL does not exist yet.

Add link to the issues board.